### PR TITLE
:bug: fix incorrect parsing of nested params with closing square bracket ] in the property name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries",
 ]
+dependencies = [
+    "regex>=2024.4.16",
+    "types-regex>=2024.4.16.20240423",
+]
 dynamic = ["version"]
 
 [project.urls]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,6 @@
-pytest>=8.1.1
+regex>=2024.4.16
+types-regex>=2024.4.16.20240423
+pytest>=8.1.2
 pytest-cov>=5.0.0
 mypy>=1.10.0
 toml>=0.10.2

--- a/src/qs_codec/decode.py
+++ b/src/qs_codec/decode.py
@@ -4,6 +4,8 @@ import re
 import typing as t
 from math import isinf
 
+from regex import regex
+
 from .enums.charset import Charset
 from .enums.duplicates import Duplicates
 from .enums.sentinel import Sentinel
@@ -159,10 +161,10 @@ def _parse_keys(given_key: t.Optional[str], val: t.Any, options: DecodeOptions, 
     key: str = re.sub(r"\.([^.[]+)", r"[\1]", given_key) if options.allow_dots else given_key
 
     # The regex chunks
-    brackets: re.Pattern[str] = re.compile(r"(\[[^[\]]*])")
+    brackets: regex.Pattern[str] = regex.compile(r"\[(?:[^\[\]]|(?R))*\]")
 
     # Get the parent
-    segment: t.Optional[t.Match] = brackets.search(key) if options.depth > 0 else None
+    segment: t.Optional[regex.Match] = brackets.search(key) if options.depth > 0 else None
     parent: str = key[0 : segment.start()] if segment is not None else key
 
     # Stash the parent if it exists
@@ -173,7 +175,7 @@ def _parse_keys(given_key: t.Optional[str], val: t.Any, options: DecodeOptions, 
     while options.depth > 0 and (segment := brackets.search(key)) is not None and i < options.depth:
         i += 1
         if segment is not None:
-            keys.append(segment.group(1))
+            keys.append(segment.group())
             # Update the key to start searching from the next position
             key = key[segment.end() :]
 

--- a/tests/unit/fixed_qs_issues_test.py
+++ b/tests/unit/fixed_qs_issues_test.py
@@ -1,0 +1,14 @@
+import typing as t
+
+from qs_codec import EncodeOptions, decode, encode
+
+
+class TestFixedQsIssues:
+    """Test cases for fixed issues."""
+
+    def test_qs_issue_493(self) -> None:
+        """Test case for https://github.com/ljharb/qs/issues/493"""
+        original: t.Dict[str, t.Any] = {"search": {"withbracket[]": "foobar"}}
+        encoded: str = "search[withbracket[]]=foobar"
+        assert encode(original, options=EncodeOptions(encode=False)) == encoded
+        assert decode(encoded) == original


### PR DESCRIPTION
## Description

Fixes incorrect parsing of nested params with closing square bracket `]` in the property name.

The regular expression you're currently in use,
```python
re.compile(r"(\[[^[\]]*])")
```
matches a left bracket `[`, followed by any number of characters that are not brackets, and then a right bracket `]`. This is why it matches the innermost brackets.

To match the outermost brackets, including nested brackets, we must use a recursive regular expression. However, Python's built-in `re` module doesn't support recursive regular expressions, so we must use the [`regex`](https://pypi.org/project/regex/) module instead, which is a third-party module that provides more advanced regular expression features.

```python
import regex

def match_outermost_brackets(s):
    pattern = r"\[(?:[^\[\]]|(?R))*\]"
    match = regex.search(pattern, s)
    return match.group() if match else None

print(match_outermost_brackets("foo[bar[]]"))  # Outputs: [bar[]]
```

Fixes https://github.com/ljharb/qs/issues/493

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `test_qs_issue_493`
```python
def test_qs_issue_493(self) -> None:
    """Test case for https://github.com/ljharb/qs/issues/493"""
    original: t.Dict[str, t.Any] = {"search": {"withbracket[]": "foobar"}}
    encoded: str = "search[withbracket[]]=foobar"
    assert encode(original, options=EncodeOptions(encode=False)) == encoded
    assert decode(encoded) == original
```


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
