### PR TITLE
:zap: decode returns `dict[str, Any]` instead of `dict`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,7 @@ over this huge ``list``.
 
    import qs_codec
 
-   assert qs_codec.decode('a[100]=b') == {'a': {100: 'b'}}
+   assert qs_codec.decode('a[100]=b') == {'a': {'100': 'b'}}
 
 This limit can be overridden by passing an `list_limit <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.models.decode_options.DecodeOptions.list_limit>`__
 option:
@@ -340,7 +340,7 @@ option:
    assert qs_codec.decode(
        'a[1]=b',
        qs_codec.DecodeOptions(list_limit=0),
-   ) == {'a': {1: 'b'}}
+   ) == {'a': {'1': 'b'}}
 
 To disable ``list`` parsing entirely, set `parse_lists <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.models.decode_options.DecodeOptions.parse_lists>`__
 to ``False``.
@@ -352,7 +352,7 @@ to ``False``.
    assert qs_codec.decode(
        'a[]=b',
        qs_codec.DecodeOptions(parse_lists=False),
-   ) == {'a': {0: 'b'}}
+   ) == {'a': {'0': 'b'}}
 
 If you mix notations, `decode <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.decode>`__ will merge the two items into a ``dict``:
 
@@ -360,7 +360,7 @@ If you mix notations, `decode <https://techouse.github.io/qs_codec/qs_codec.mode
 
    import qs_codec
 
-   assert qs_codec.decode('a[0]=b&a[b]=c') == {'a': {0: 'b', 'b': 'c'}}
+   assert qs_codec.decode('a[0]=b&a[b]=c') == {'a': {'0': 'b', 'b': 'c'}}
 
 You can also create ``list``\ s of ``dict``\ s:
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ dictionaries
    def decode(
        value: t.Optional[t.Union[str, t.Mapping]],
        options: qs_codec.DecodeOptions = qs_codec.DecodeOptions(),
-   ) -> dict:
+   ) -> t.Dict[str, t.Any]:
        """Decodes a str or Mapping into a Dict. 
        
        Providing custom DecodeOptions will override the default behavior."""

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -11,7 +11,7 @@ dictionaries
    def decode(
        value: t.Optional[t.Union[str, t.Mapping]],
        options: qs_codec.DecodeOptions = qs_codec.DecodeOptions(),
-   ) -> dict:
+   ) -> t.Dict[str, t.Any]:
        """Decodes a str or Mapping into a Dict. 
        
        Providing custom DecodeOptions will override the default behavior."""

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -303,7 +303,7 @@ over this huge ``list``.
 
    import qs_codec
 
-   assert qs_codec.decode('a[100]=b') == {'a': {100: 'b'}}
+   assert qs_codec.decode('a[100]=b') == {'a': {'100': 'b'}}
 
 This limit can be overridden by passing an :py:attr:`list_limit <qs_codec.models.decode_options.DecodeOptions.list_limit>`
 option:
@@ -315,7 +315,7 @@ option:
    assert qs_codec.decode(
        'a[1]=b',
        qs_codec.DecodeOptions(list_limit=0),
-   ) == {'a': {1: 'b'}}
+   ) == {'a': {'1': 'b'}}
 
 To disable ``list`` parsing entirely, set :py:attr:`parse_lists <qs_codec.models.decode_options.DecodeOptions.parse_lists>`
 to ``False``.
@@ -327,7 +327,7 @@ to ``False``.
    assert qs_codec.decode(
        'a[]=b',
        qs_codec.DecodeOptions(parse_lists=False),
-   ) == {'a': {0: 'b'}}
+   ) == {'a': {'0': 'b'}}
 
 If you mix notations, :py:attr:`decode <qs_codec.decode>` will merge the two items into a ``dict``:
 
@@ -335,7 +335,7 @@ If you mix notations, :py:attr:`decode <qs_codec.decode>` will merge the two ite
 
    import qs_codec
 
-   assert qs_codec.decode('a[0]=b&a[b]=c') == {'a': {0: 'b', 'b': 'c'}}
+   assert qs_codec.decode('a[0]=b&a[b]=c') == {'a': {'0': 'b', 'b': 'c'}}
 
 You can also create ``list``\ s of ``dict``\ s:
 

--- a/src/qs_codec/utils/utils.py
+++ b/src/qs_codec/utils/utils.py
@@ -15,10 +15,10 @@ class Utils:
 
     @staticmethod
     def merge(
-        target: t.Optional[t.Union[t.Mapping, t.List, t.Tuple]],
-        source: t.Optional[t.Union[t.Mapping, t.List, t.Tuple, t.Any]],
+        target: t.Optional[t.Union[t.Mapping[str, t.Any], t.List[t.Any], t.Tuple]],
+        source: t.Optional[t.Union[t.Mapping[str, t.Any], t.List[t.Any], t.Tuple, t.Any]],
         options: DecodeOptions = DecodeOptions(),
-    ) -> t.Union[t.Dict, t.List, t.Tuple, t.Any]:
+    ) -> t.Union[t.Dict[str, t.Any], t.List, t.Tuple, t.Any]:
         """Merge two objects together."""
         if source is None:
             return target
@@ -60,7 +60,7 @@ class Utils:
                 if isinstance(source, (list, tuple)):
                     target = {
                         **target,
-                        **{i: item for i, item in enumerate(source) if not isinstance(item, Undefined)},
+                        **{str(i): item for i, item in enumerate(source) if not isinstance(item, Undefined)},
                     }
             elif source is not None:
                 if not isinstance(target, (list, tuple)) and isinstance(source, (list, tuple)):
@@ -72,7 +72,7 @@ class Utils:
         if target is None or not isinstance(target, t.Mapping):
             if isinstance(target, (list, tuple)):
                 return {
-                    **{i: item for i, item in enumerate(target) if not isinstance(item, Undefined)},
+                    **{str(i): item for i, item in enumerate(target) if not isinstance(item, Undefined)},
                     **source,
                 }
 
@@ -86,8 +86,8 @@ class Utils:
                 if not isinstance(el, Undefined)
             ]
 
-        merge_target: t.Dict = (
-            dict(enumerate(el for el in source if not isinstance(el, Undefined)))
+        merge_target: t.Dict[str, t.Any] = (
+            {str(i): el for i, el in enumerate(source) if not isinstance(el, Undefined)}
             if isinstance(target, (list, tuple)) and not isinstance(source, (list, tuple))
             else copy.deepcopy(dict(target) if not isinstance(target, dict) else target)
         )
@@ -95,15 +95,15 @@ class Utils:
         return {
             **merge_target,
             **{
-                key: Utils.merge(merge_target[key], value, options) if key in merge_target else value
+                str(key): Utils.merge(merge_target[key], value, options) if key in merge_target else value
                 for key, value in source.items()
             },
         }
 
     @staticmethod
-    def compact(value: t.Dict) -> t.Dict:
+    def compact(value: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
         """Remove all `Undefined` values from a dictionary."""
-        queue: t.List[t.Dict] = [{"obj": {"o": value}, "prop": "o"}]
+        queue: t.List[t.Dict[str, t.Any]] = [{"obj": {"o": value}, "prop": "o"}]
         refs: t.List = []
 
         for i in range(len(queue)):  # pylint: disable=C0200

--- a/tests/unit/decode_test.py
+++ b/tests/unit/decode_test.py
@@ -18,7 +18,7 @@ class TestDecode:
     @pytest.mark.parametrize(
         "encoded, decoded, options",
         [
-            ("0=foo", {0: "foo"}, None),
+            ("0=foo", {"0": "foo"}, None),
             ("foo=c++", {"foo": "c  "}, None),
             ("a[>=]=23", {"a": {">=": "23"}}, None),
             ("a[<=>]==23", {"a": {"<=>": "=23"}}, None),
@@ -189,14 +189,14 @@ class TestDecode:
         assert decode("a[1]=c&a[0]=b&a[2]=d") == {"a": ["b", "c", "d"]}
         assert decode("a[1]=c&a[0]=b") == {"a": ["b", "c"]}
         assert decode("a[1]=c", DecodeOptions(list_limit=20)) == {"a": ["c"]}
-        assert decode("a[1]=c", DecodeOptions(list_limit=0)) == {"a": {1: "c"}}
+        assert decode("a[1]=c", DecodeOptions(list_limit=0)) == {"a": {"1": "c"}}
         assert decode("a[1]=c") == {"a": ["c"]}
 
     def test_limits_specific_list_indices_to_list_limit(self) -> None:
         assert decode("a[20]=a", DecodeOptions(list_limit=20)) == {"a": ["a"]}
-        assert decode("a[21]=a", DecodeOptions(list_limit=20)) == {"a": {21: "a"}}
+        assert decode("a[21]=a", DecodeOptions(list_limit=20)) == {"a": {"21": "a"}}
         assert decode("a[20]=a") == {"a": ["a"]}
-        assert decode("a[21]=a") == {"a": {21: "a"}}
+        assert decode("a[21]=a") == {"a": {"21": "a"}}
 
     def test_supports_keys_that_begin_with_a_number(self) -> None:
         assert decode("a[12b]=c") == {"a": {"12b": "c"}}
@@ -217,11 +217,11 @@ class TestDecode:
         assert decode(None) == {}
 
     def test_transforms_lists_to_dicts(self) -> None:
-        assert decode("foo[0]=bar&foo[bad]=baz") == {"foo": {0: "bar", "bad": "baz"}}
-        assert decode("foo[bad]=baz&foo[0]=bar") == {"foo": {"bad": "baz", 0: "bar"}}
-        assert decode("foo[bad]=baz&foo[]=bar") == {"foo": {"bad": "baz", 0: "bar"}}
-        assert decode("foo[]=bar&foo[bad]=baz") == {"foo": {0: "bar", "bad": "baz"}}
-        assert decode("foo[bad]=baz&foo[]=bar&foo[]=foo") == {"foo": {"bad": "baz", 0: "bar", 1: "foo"}}
+        assert decode("foo[0]=bar&foo[bad]=baz") == {"foo": {"0": "bar", "bad": "baz"}}
+        assert decode("foo[bad]=baz&foo[0]=bar") == {"foo": {"bad": "baz", "0": "bar"}}
+        assert decode("foo[bad]=baz&foo[]=bar") == {"foo": {"bad": "baz", "0": "bar"}}
+        assert decode("foo[]=bar&foo[bad]=baz") == {"foo": {"0": "bar", "bad": "baz"}}
+        assert decode("foo[bad]=baz&foo[]=bar&foo[]=foo") == {"foo": {"bad": "baz", "0": "bar", "1": "foo"}}
         assert decode("foo[0][a]=a&foo[0][b]=b&foo[1][a]=aa&foo[1][b]=bb") == {
             "foo": [{"a": "a", "b": "b"}, {"a": "aa", "b": "bb"}]
         }
@@ -245,18 +245,18 @@ class TestDecode:
         assert decode("foo[0].baz[0]=15&foo[0].baz[1]=16&foo[0].bar=2", DecodeOptions(allow_dots=True)) == {
             "foo": [{"baz": ["15", "16"], "bar": "2"}]
         }
-        assert decode("foo.bad=baz&foo[0]=bar", DecodeOptions(allow_dots=True)) == {"foo": {"bad": "baz", 0: "bar"}}
-        assert decode("foo.bad=baz&foo[]=bar", DecodeOptions(allow_dots=True)) == {"foo": {"bad": "baz", 0: "bar"}}
-        assert decode("foo[]=bar&foo.bad=baz", DecodeOptions(allow_dots=True)) == {"foo": {0: "bar", "bad": "baz"}}
+        assert decode("foo.bad=baz&foo[0]=bar", DecodeOptions(allow_dots=True)) == {"foo": {"bad": "baz", "0": "bar"}}
+        assert decode("foo.bad=baz&foo[]=bar", DecodeOptions(allow_dots=True)) == {"foo": {"bad": "baz", "0": "bar"}}
+        assert decode("foo[]=bar&foo.bad=baz", DecodeOptions(allow_dots=True)) == {"foo": {"0": "bar", "bad": "baz"}}
         assert decode("foo.bad=baz&foo[]=bar&foo[]=foo", DecodeOptions(allow_dots=True)) == {
-            "foo": {"bad": "baz", 0: "bar", 1: "foo"}
+            "foo": {"bad": "baz", "0": "bar", "1": "foo"}
         }
         assert decode("foo[0].a=a&foo[0].b=b&foo[1].a=aa&foo[1].b=bb", DecodeOptions(allow_dots=True)) == {
             "foo": [{"a": "a", "b": "b"}, {"a": "aa", "b": "bb"}]
         }
 
     def test_correctly_prunes_undefined_values_when_converting_a_list_to_a_dict(self) -> None:
-        assert decode("a[2]=b&a[99999999]=c") == {"a": {2: "b", 99999999: "c"}}
+        assert decode("a[2]=b&a[99999999]=c") == {"a": {"2": "b", "99999999": "c"}}
 
     def test_supports_malformed_uri_characters(self) -> None:
         assert decode("{%:%}", DecodeOptions(strict_null_handling=True)) == {"{%:%}": None}
@@ -307,8 +307,8 @@ class TestDecode:
         ) == {"filter": [["int1", "=", "77"], "and", ["int2", "=", "8"]]}
 
     def test_continues_parsing_when_no_parent_is_found(self) -> None:
-        assert decode("[]=&a=b") == {0: "", "a": "b"}
-        assert decode("[]&a=b", DecodeOptions(strict_null_handling=True)) == {0: None, "a": "b"}
+        assert decode("[]=&a=b") == {"0": "", "a": "b"}
+        assert decode("[]&a=b", DecodeOptions(strict_null_handling=True)) == {"0": None, "a": "b"}
         assert decode("[foo]=bar") == {"foo": "bar"}
 
     def test_does_not_error_when_parsing_a_very_long_list(self) -> None:
@@ -333,16 +333,16 @@ class TestDecode:
         assert decode("a=b&c=d", DecodeOptions(parameter_limit=float("inf"))) == {"a": "b", "c": "d"}
 
     def test_allows_overriding_list_limit(self) -> None:
-        assert decode("a[0]=b", DecodeOptions(list_limit=-1)) == {"a": {0: "b"}}
+        assert decode("a[0]=b", DecodeOptions(list_limit=-1)) == {"a": {"0": "b"}}
         assert decode("a[0]=b", DecodeOptions(list_limit=0)) == {"a": ["b"]}
-        assert decode("a[-1]=b", DecodeOptions(list_limit=-1)) == {"a": {-1: "b"}}
-        assert decode("a[-1]=b", DecodeOptions(list_limit=0)) == {"a": {-1: "b"}}
-        assert decode("a[0]=b&a[1]=c", DecodeOptions(list_limit=-1)) == {"a": {0: "b", 1: "c"}}
-        assert decode("a[0]=b&a[1]=c", DecodeOptions(list_limit=0)) == {"a": {0: "b", 1: "c"}}
+        assert decode("a[-1]=b", DecodeOptions(list_limit=-1)) == {"a": {"-1": "b"}}
+        assert decode("a[-1]=b", DecodeOptions(list_limit=0)) == {"a": {"-1": "b"}}
+        assert decode("a[0]=b&a[1]=c", DecodeOptions(list_limit=-1)) == {"a": {"0": "b", "1": "c"}}
+        assert decode("a[0]=b&a[1]=c", DecodeOptions(list_limit=0)) == {"a": {"0": "b", "1": "c"}}
 
     def test_allows_disabling_list_parsing(self) -> None:
-        assert decode("a[0]=b&a[1]=c", DecodeOptions(parse_lists=False)) == {"a": {0: "b", 1: "c"}}
-        assert decode("a[]=b", DecodeOptions(parse_lists=False)) == {"a": {0: "b"}}
+        assert decode("a[0]=b&a[1]=c", DecodeOptions(parse_lists=False)) == {"a": {"0": "b", "1": "c"}}
+        assert decode("a[]=b", DecodeOptions(parse_lists=False)) == {"a": {"0": "b"}}
 
     def test_allows_for_query_string_prefix(self) -> None:
         assert decode("?foo=bar", DecodeOptions(ignore_query_prefix=True)) == {"foo": "bar"}
@@ -486,7 +486,7 @@ class TestDecode:
 
         expected_list: t.Dict[str, t.Any] = {}
         expected_list["a"] = {}
-        expected_list["a"][0] = "b"
+        expected_list["a"]["0"] = "b"
         expected_list["a"]["c"] = "d"
         assert decode("a[]=b&a[c]=d") == expected_list
 
@@ -533,10 +533,10 @@ class TestDecode:
             ("a[0]=b&a=c&=", {"a": ["b", "c"]}),
             ("a=b&a[]=c&=", {"a": ["b", "c"]}),
             ("a=b&a[0]=c&=", {"a": ["b", "c"]}),
-            ("[]=a&[]=b& []=1", {0: "a", 1: "b", " ": ["1"]}),
-            ("[0]=a&[1]=b&a[0]=1&a[1]=2", {0: "a", 1: "b", "a": ["1", "2"]}),
+            ("[]=a&[]=b& []=1", {"0": "a", "1": "b", " ": ["1"]}),
+            ("[0]=a&[1]=b&a[0]=1&a[1]=2", {"0": "a", "1": "b", "a": ["1", "2"]}),
             ("[deep]=a&[deep]=2", {"deep": ["a", "2"]}),
-            ("%5B0%5D=a&%5B1%5D=b", {0: "a", 1: "b"}),
+            ("%5B0%5D=a&%5B1%5D=b", {"0": "a", "1": "b"}),
         ],
     )
     def test_parses_empty_keys(self, encoded: str, decoded: t.Mapping) -> None:

--- a/tests/unit/example_test.py
+++ b/tests/unit/example_test.py
@@ -130,16 +130,16 @@ class TestDecoding:
         # Any `list` members with an index of greater than `20` will instead be converted to a `dict` with the index as
         # the key. This is needed to handle cases when someone sent, for example, `a[999999999]` and it will take
         # significant time to iterate over this huge `list`.
-        assert qs_codec.decode("a[100]=b") == {"a": {100: "b"}}
+        assert qs_codec.decode("a[100]=b") == {"a": {"100": "b"}}
 
         # This limit can be overridden by passing an `DecodeOptions.list_limit` option:
-        assert qs_codec.decode("a[1]=b", qs_codec.DecodeOptions(list_limit=0)) == {"a": {1: "b"}}
+        assert qs_codec.decode("a[1]=b", qs_codec.DecodeOptions(list_limit=0)) == {"a": {"1": "b"}}
 
         # To disable List parsing entirely, set `DecodeOptions.parse_lists` to `False`.
-        assert qs_codec.decode("a[]=b", qs_codec.DecodeOptions(parse_lists=False)) == {"a": {0: "b"}}
+        assert qs_codec.decode("a[]=b", qs_codec.DecodeOptions(parse_lists=False)) == {"a": {"0": "b"}}
 
         # If you mix notations, **qs_codec** will merge the two items into a `dict`:
-        assert qs_codec.decode("a[0]=b&a[b]=c") == {"a": {0: "b", "b": "c"}}
+        assert qs_codec.decode("a[0]=b&a[b]=c") == {"a": {"0": "b", "b": "c"}}
 
         # You can also create `list`s of `dict`s:
         # (**qs_codec** cannot convert nested `dict`s, such as `'a={b:1},{c:d}'`)

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -421,7 +421,7 @@ class TestUtils:
         assert DecodeUtils.unescape(escaped) == unescaped
 
     def test_merges_dict_with_list(self) -> None:
-        assert Utils.merge({0: "a"}, [Undefined(), "b"]) == {0: "a", 1: "b"}
+        assert Utils.merge({"0": "a"}, [Undefined(), "b"]) == {"0": "a", "1": "b"}
 
     def test_merges_two_dicts_with_the_same_key_and_different_values(self) -> None:
         assert Utils.merge({"foo": [{"a": "a", "b": "b"}, {"a": "aa"}]}, {"foo": [Undefined(), {"b": "bb"}]}) == {
@@ -450,7 +450,7 @@ class TestUtils:
 
     def test_merges_standalone_and_two_objects_into_array(self) -> None:
         assert Utils.merge({"foo": ["bar", {"first": "123"}]}, {"foo": {"second": "456"}}) == {
-            "foo": {0: "bar", 1: {"first": "123"}, "second": "456"}
+            "foo": {"0": "bar", "1": {"first": "123"}, "second": "456"}
         }
 
     def test_merges_object_sandwiched_by_two_standalones_into_array(self) -> None:
@@ -462,13 +462,13 @@ class TestUtils:
         assert Utils.merge({"foo": ["baz"]}, {"foo": ["bar", "xyzzy"]}) == {"foo": ["baz", "bar", "xyzzy"]}
 
     def test_merges_object_into_array(self) -> None:
-        assert Utils.merge({"foo": ["bar"]}, {"foo": {"baz": "xyzzy"}}) == {"foo": {0: "bar", "baz": "xyzzy"}}
+        assert Utils.merge({"foo": ["bar"]}, {"foo": {"baz": "xyzzy"}}) == {"foo": {"0": "bar", "baz": "xyzzy"}}
 
     def test_merges_array_into_object(self) -> None:
         assert Utils.merge(
             {"foo": {"bar": "baz"}},
             {"foo": ["xyzzy"]},
-        ) == {"foo": {"bar": "baz", 0: "xyzzy"}}
+        ) == {"foo": {"bar": "baz", "0": "xyzzy"}}
 
     def test_combine_both_arrays(self) -> None:
         a = [1]


### PR DESCRIPTION
## Description

`decode` now returns `dict[str, Any]` instead of `dict`.

NOTE: This means that all decoded `dict` keys will now be `str`ings.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

The tests have been updated to reflect the change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated type annotations in documentation for better clarity and accuracy.

- **Bug Fixes**
  - Ensured dictionary keys are correctly handled as strings in decoding operations.

- **Tests**
  - Modified test cases to reflect changes from integer keys to string keys in dictionaries.

- **Refactor**
  - Improved type hints for better code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->