### PR TITLE
:bug: fix `decode`: properly account for `strict_null_handling` when `allow_empty_lists`

### DIFF
--- a/src/qs_codec/decode.py
+++ b/src/qs_codec/decode.py
@@ -129,7 +129,7 @@ def _parse_object(
         root: str = chain[i]
 
         if root == "[]" and options.parse_lists:
-            if options.allow_empty_lists and leaf == "":
+            if options.allow_empty_lists and (leaf == "" or (options.strict_null_handling and leaf is None)):
                 obj = []
             else:
                 obj = list(leaf) if isinstance(leaf, (list, tuple)) else [leaf]

--- a/tests/unit/decode_test.py
+++ b/tests/unit/decode_test.py
@@ -137,6 +137,11 @@ class TestDecode:
         assert decode("foo[]&bar=baz", DecodeOptions(allow_empty_lists=True)) == {"foo": [], "bar": "baz"}
         assert decode("foo[]&bar=baz", DecodeOptions(allow_empty_lists=False)) == {"foo": [""], "bar": "baz"}
 
+    def test_allow_empty_lists_and_strict_null_handling(self) -> None:
+        assert decode("testEmptyList[]", DecodeOptions(strict_null_handling=True, allow_empty_lists=True)) == {
+            "testEmptyList": []
+        }
+
     def test_parses_a_single_nested_string(self) -> None:
         assert decode("a[b]=c") == {"a": {"b": "c"}}
 

--- a/tests/unit/encode_test.py
+++ b/tests/unit/encode_test.py
@@ -236,6 +236,12 @@ class TestEncode:
         assert encode({"a": [], "b": "zz"}, options=EncodeOptions(allow_empty_lists=False)) == "b=zz"
         assert encode({"a": [], "b": "zz"}, options=EncodeOptions(allow_empty_lists=True)) == "a[]&b=zz"
 
+    def test_empty_list_with_strict_null_handling(self) -> None:
+        assert (
+            encode({"testEmptyList": []}, options=EncodeOptions(strict_null_handling=True, allow_empty_lists=True))
+            == "testEmptyList[]"
+        )
+
     def test_encodes_a_nested_list_value(self) -> None:
         assert (
             encode(


### PR DESCRIPTION
## Description

Fix `decode` output when both `strict_null_handling` and `allow_empty_lists` are set to `True`.

Fixes https://github.com/ljharb/qs/issues/510

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added new tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved list handling functionality with new `strict_null_handling` option.

- **Tests**
  - Added tests for decoding and encoding with empty lists and strict null handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->