### PR TITLE
:sparkles: DecodeOptions.strict_depth option to throw when input is beyond depth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,8 +93,24 @@ This depth can be overridden by setting the `depth <https://techouse.github.io/q
        qs.DecodeOptions(depth=1),
    ) == {'a': {'b': {'[c][d][e][f][g][h][i]': 'j'}}}
 
+You can configure `decode <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.decode>`__ to throw an error
+when parsing nested input beyond this depth using `strict_depth <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.models.decode_options.DecodeOptions.strict_depth>`__ (defaults to ``False``):
+
+.. code:: python
+
+   import qs_codec as qs
+
+   try:
+       qs.decode(
+           'a[b][c][d][e][f][g][h][i]=j',
+           qs.DecodeOptions(depth=1, strict_depth=True),
+       )
+   except IndexError as e:
+       assert str(e) == 'Input depth exceeded depth option of 1 and strict_depth is True'
+
 The depth limit helps mitigate abuse when `decode <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.decode>`__ is used to parse user
-input, and it is recommended to keep it a reasonably small number.
+input, and it is recommended to keep it a reasonably small number. `strict_depth <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.models.decode_options.DecodeOptions.strict_depth>`__
+adds a layer of protection by throwing a ``IndexError`` when the limit is exceeded, allowing you to catch and handle such cases.
 
 For similar reasons, by default `decode <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.decode>`__ will only parse up to 1000 parameters. This can be overridden by passing a
 `parameter_limit <https://techouse.github.io/qs_codec/qs_codec.models.html#qs_codec.models.decode_options.DecodeOptions.parameter_limit>`__ option:

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -67,8 +67,25 @@ This depth can be overridden by setting the :py:attr:`depth <qs_codec.models.dec
        qs.DecodeOptions(depth=1),
    ) == {'a': {'b': {'[c][d][e][f][g][h][i]': 'j'}}}
 
-The depth limit helps mitigate abuse when :py:attr:`decode <qs_codec.decode>` is used to parse user
-input, and it is recommended to keep it a reasonably small number.
+
+You can configure :py:attr:`decode <qs_codec.decode>` to throw an error
+when parsing nested input beyond this depth using :py:attr:`strict_depth <qs_codec.models.decode_options.DecodeOptions.strict_depth>` (defaults to ``False``):
+
+.. code:: python
+
+   import qs_codec as qs
+
+   try:
+       qs.decode(
+           'a[b][c][d][e][f][g][h][i]=j',
+           qs.DecodeOptions(depth=1, strict_depth=True),
+       )
+   except IndexError as e:
+       assert str(e) == 'Input depth exceeded depth option of 1 and strict_depth is True'
+
+The depth limit helps mitigate abuse when :py:attr:`decode <qs_codec.decode>` is used to parse user input, and it is recommended
+to keep it a reasonably small number. :py:attr:`strict_depth <qs_codec.models.decode_options.DecodeOptions.strict_depth>`
+adds a layer of protection by throwing a ``IndexError`` when the limit is exceeded, allowing you to catch and handle such cases.
 
 For similar reasons, by default :py:attr:`decode <qs_codec.decode>` will only parse up to 1000 parameters. This can be overridden by passing a
 :py:attr:`parameter_limit <qs_codec.models.decode_options.DecodeOptions.parameter_limit>` option:

--- a/src/qs_codec/decode.py
+++ b/src/qs_codec/decode.py
@@ -194,6 +194,8 @@ def _parse_keys(given_key: t.Optional[str], val: t.Any, options: DecodeOptions, 
 
     # If there's a remainder, just add whatever is left
     if segment is not None:
+        if options.strict_depth:
+            raise IndexError(f"Input depth exceeded depth option of {options.depth} and strict_depth is True")
         keys.append(f"[{key[segment.start():]}]")
 
     return _parse_object(keys, val, options, values_parsed)

--- a/src/qs_codec/models/decode_options.py
+++ b/src/qs_codec/models/decode_options.py
@@ -77,6 +77,9 @@ class DecodeOptions:
     parse_lists: bool = True
     """To disable ``list`` parsing entirely, set ``parse_lists`` to ``False``."""
 
+    strict_depth: bool = False
+    """Set to ``True`` to throw an error when the input exceeds the ``depth`` limit."""
+
     strict_null_handling: bool = False
     """Set to true to decode values without ``=`` to ``None``."""
 


### PR DESCRIPTION
## Description

This PR adds `DecodeOptions.strict_depth` to enforce throwing when input depth is beyond the depth option.

Defaults to `false`.

Throws `RangeError`.

If depth has been set by the user to `0`, we do not throw, but fallback to the previous behaviour.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added additional tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---

Ref https://github.com/ljharb/qs/pull/511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the decoding process to enforce stricter input depth validation.
	- Introduced a new `strict_depth` option allowing users to configure depth limits during decoding.

- **Bug Fixes**
	- Improved robustness by raising `IndexError` when depth exceeds limits with `strict_depth` enabled.

- **Tests**
	- Added tests to validate the behavior of the `decode` function with the new `strict_depth` parameter, ensuring expected error handling for nested inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->