### PR TITLE
:hammer: enhance type hints and improve code clarity across multiple modules

### DIFF
--- a/src/qs_codec/__init__.py
+++ b/src/qs_codec/__init__.py
@@ -12,3 +12,17 @@ from .enums.sentinel import Sentinel
 from .models.decode_options import DecodeOptions
 from .models.encode_options import EncodeOptions
 from .models.undefined import Undefined
+
+
+__all__ = [
+    "decode",
+    "encode",
+    "Charset",
+    "Duplicates",
+    "Format",
+    "ListFormat",
+    "Sentinel",
+    "DecodeOptions",
+    "EncodeOptions",
+    "Undefined",
+]

--- a/src/qs_codec/decode.py
+++ b/src/qs_codec/decode.py
@@ -116,7 +116,7 @@ def _parse_query_string_values(value: str, options: DecodeOptions) -> t.Dict[str
         pos: int = part.find("=") if bracket_equals_pos == -1 else (bracket_equals_pos + 1)
 
         key: str
-        val: t.Union[t.List, t.Tuple, str, t.Any]
+        val: t.Union[t.List[t.Any], t.Tuple[t.Any], str, t.Any]
         if pos == -1:
             key = options.decoder(part, charset)
             val = None if options.strict_null_handling else ""
@@ -134,7 +134,7 @@ def _parse_query_string_values(value: str, options: DecodeOptions) -> t.Dict[str
         if val and options.interpret_numeric_entities and charset == Charset.LATIN1:
             val = _interpret_numeric_entities(
                 val if isinstance(val, str) else ",".join(val) if isinstance(val, (list, tuple)) else str(val)
-            )  # type: ignore [arg-type]
+            )
 
         if "[]=" in part:
             val = [val] if isinstance(val, (list, tuple)) else val

--- a/src/qs_codec/encode.py
+++ b/src/qs_codec/encode.py
@@ -183,12 +183,12 @@ def _encode(
 
         return [f"{formatter(prefix)}={formatter(str(obj))}"]
 
-    values: t.List = []
+    values: t.List[t.Any] = []
 
     if is_undefined:
         return values
 
-    obj_keys: t.List
+    obj_keys: t.List[t.Any]
     if generate_array_prefix == ListFormat.COMMA.generator and isinstance(obj, (list, tuple)):
         # we need to join elements in
         if encode_values_only and callable(encoder):
@@ -202,7 +202,7 @@ def _encode(
     elif isinstance(filter, (list, tuple)):
         obj_keys = list(filter)
     else:
-        keys: t.List
+        keys: t.List[t.Any]
         if isinstance(obj, t.Mapping):
             keys = list(obj.keys())
         elif isinstance(obj, (list, tuple)):

--- a/src/qs_codec/models/decode_options.py
+++ b/src/qs_codec/models/decode_options.py
@@ -89,7 +89,7 @@ class DecodeOptions:
     decoder: t.Callable[[t.Optional[str], t.Optional[Charset]], t.Any] = DecodeUtils.decode
     """Set a ``Callable`` to affect the decoding of the input."""
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Post-initialization."""
         if self.allow_dots is None:
             self.allow_dots = self.decode_dot_in_keys is True or False

--- a/src/qs_codec/models/encode_options.py
+++ b/src/qs_codec/models/encode_options.py
@@ -81,7 +81,7 @@ class EncodeOptions:
 
     @encoder.setter
     def encoder(self, value: t.Optional[t.Callable[[t.Any, t.Optional[Charset], t.Optional[Format]], str]]) -> None:
-        self._encoder = value if callable(value) else EncodeUtils.encode  # type: ignore [assignment]
+        self._encoder = value if callable(value) else EncodeUtils.encode
 
     strict_null_handling: bool = False
     """Set to ``True`` to distinguish between ``null`` values and empty ``str``\\ings. This way the encoded string
@@ -94,7 +94,7 @@ class EncodeOptions:
     sort: t.Optional[t.Callable[[t.Any, t.Any], int]] = field(default=None)
     """Set a ``Callable`` to affect the order of parameter keys."""
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Post-initialization."""
         if self.allow_dots is None:
             self.allow_dots = self.encode_dot_in_keys is True or False

--- a/src/qs_codec/models/undefined.py
+++ b/src/qs_codec/models/undefined.py
@@ -1,13 +1,15 @@
 """Undefined class definition."""
 
+import typing as t
+
 
 class Undefined:
     """Singleton class to represent undefined values."""
 
     _instance = None
 
-    def __new__(cls):
+    def __new__(cls: t.Type["Undefined"]) -> "Undefined":
         """Create a new instance of the class."""
         if cls._instance is None:
-            cls._instance = super(Undefined, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
         return cls._instance

--- a/src/qs_codec/models/weak_wrapper.py
+++ b/src/qs_codec/models/weak_wrapper.py
@@ -15,7 +15,12 @@ class WeakWrapper:
         return hash(self._hash_recursive(self.value, seen=set(), stack=set()))
 
     def _hash_recursive(
-        self, value: t.Any, seen: set, stack: set, depth: int = 0, max_depth: int = 1000
+        self,
+        value: t.Any,
+        seen: t.Set[t.Any],
+        stack: t.Set[t.Any],
+        depth: int = 0,
+        max_depth: int = 1000,
     ) -> t.Union[t.Tuple, t.Any]:
         """Recursively hash a value."""
         if id(value) in stack:

--- a/src/qs_codec/utils/decode_utils.py
+++ b/src/qs_codec/utils/decode_utils.py
@@ -33,8 +33,7 @@ class DecodeUtils:
                 return chr(int(unicode_val, 16))
             elif (hex_val := match.group("hex")) is not None:
                 return chr(int(hex_val, 16))
-            # match.group(0) is always non-None, so cast it to str for mypy.
-            return t.cast(str, match.group(0))
+            return match.group(0)
 
         return cls.UNESCAPE_PATTERN.sub(replacer, string)
 

--- a/src/qs_codec/utils/utils.py
+++ b/src/qs_codec/utils/utils.py
@@ -15,10 +15,10 @@ class Utils:
 
     @staticmethod
     def merge(
-        target: t.Optional[t.Union[t.Mapping[str, t.Any], t.List[t.Any], t.Tuple]],
-        source: t.Optional[t.Union[t.Mapping[str, t.Any], t.List[t.Any], t.Tuple, t.Any]],
+        target: t.Optional[t.Union[t.Mapping[str, t.Any], t.List[t.Any], t.Tuple[t.Any]]],
+        source: t.Optional[t.Union[t.Mapping[str, t.Any], t.List[t.Any], t.Tuple[t.Any], t.Any]],
         options: DecodeOptions = DecodeOptions(),
-    ) -> t.Union[t.Dict[str, t.Any], t.List, t.Tuple, t.Any]:
+    ) -> t.Union[t.Dict[str, t.Any], t.List[t.Any], t.Tuple[t.Any], t.Any]:
         """Merge two objects together."""
         if source is None:
             return target
@@ -107,13 +107,13 @@ class Utils:
     def compact(value: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
         """Remove all `Undefined` values from a dictionary."""
         queue: t.List[t.Dict[str, t.Any]] = [{"obj": {"o": value}, "prop": "o"}]
-        refs: t.List = []
+        refs: t.List[t.Any] = []
 
         for i in range(len(queue)):  # pylint: disable=C0200
-            item: t.Mapping = queue[i]
-            obj: t.Mapping = item["obj"][item["prop"]]
+            item: t.Mapping[t.Any, t.Any] = queue[i]
+            obj: t.Mapping[t.Any, t.Any] = item["obj"][item["prop"]]
 
-            keys: t.List = list(obj.keys())
+            keys: t.List[t.Any] = list(obj.keys())
             for key in keys:
                 val = obj.get(key)
 
@@ -131,7 +131,7 @@ class Utils:
         return value
 
     @staticmethod
-    def _remove_undefined_from_list(value: t.List) -> None:
+    def _remove_undefined_from_list(value: t.List[t.Any]) -> None:
         i: int = len(value) - 1
         while i >= 0:
             item = value[i]
@@ -147,8 +147,8 @@ class Utils:
             i -= 1
 
     @staticmethod
-    def _remove_undefined_from_map(obj: t.Dict) -> None:
-        keys: t.List = list(obj.keys())
+    def _remove_undefined_from_map(obj: t.Dict[t.Any, t.Any]) -> None:
+        keys: t.List[t.Any] = list(obj.keys())
         for key in keys:
             val = obj[key]
             if isinstance(val, Undefined):
@@ -162,7 +162,11 @@ class Utils:
                 Utils._remove_undefined_from_list(obj[key])
 
     @staticmethod
-    def _dicts_are_equal(d1: t.Mapping, d2: t.Mapping, path=None) -> bool:
+    def _dicts_are_equal(
+        d1: t.Mapping[t.Any, t.Any],
+        d2: t.Mapping[t.Any, t.Any],
+        path: t.Optional[t.Set[t.Any]] = None,
+    ) -> bool:
         if path is None:
             path = set()
 
@@ -185,12 +189,18 @@ class Utils:
             return d1 == d2
 
     @staticmethod
-    def combine(a: t.Union[list, tuple, t.Any], b: t.Union[list, tuple, t.Any]) -> t.List:
+    def combine(
+        a: t.Union[t.List[t.Any], t.Tuple[t.Any], t.Any],
+        b: t.Union[t.List[t.Any], t.Tuple[t.Any], t.Any],
+    ) -> t.List[t.Any]:
         """Combine two lists or values."""
         return [*(a if isinstance(a, (list, tuple)) else [a]), *(b if isinstance(b, (list, tuple)) else [b])]
 
     @staticmethod
-    def apply(val: t.Union[list, tuple, t.Any], fn: t.Callable) -> t.Union[t.List, t.Any]:
+    def apply(
+        val: t.Union[t.List[t.Any], t.Tuple[t.Any], t.Any],
+        fn: t.Callable,
+    ) -> t.Union[t.List[t.Any], t.Any]:
         """Apply a function to a value or a list of values."""
         return [fn(item) for item in val] if isinstance(val, (list, tuple)) else fn(val)
 


### PR DESCRIPTION
This pull request includes several changes to improve type annotations and code clarity across various modules in the `qs_codec` package. The most significant changes involve adding type hints to function signatures and refining existing type annotations.

### Type Annotation Improvements:

* [`src/qs_codec/__init__.py`](diffhunk://#diff-e00119892283370ef59a1f7997fee170ffe542d4de6058ca4e2be32569887a3fR15-R28): Added `__all__` to specify the public API of the module.
* [`src/qs_codec/decode.py`](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L119-R119): Refined type annotations for `val` in `_parse_query_string_values` function to specify list and tuple element types. [[1]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L119-R119) [[2]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L137-R137)
* [`src/qs_codec/encode.py`](diffhunk://#diff-a1d443c188edfa1734eca359a4ebca123ce86b539c9084a9f6eee19195e435a3L186-R191): Updated type annotations for `values` and `obj_keys` in `_encode` function to specify element types. [[1]](diffhunk://#diff-a1d443c188edfa1734eca359a4ebca123ce86b539c9084a9f6eee19195e435a3L186-R191) [[2]](diffhunk://#diff-a1d443c188edfa1734eca359a4ebca123ce86b539c9084a9f6eee19195e435a3L205-R205)

### Code Clarity Enhancements:

* [`src/qs_codec/models/decode_options.py`](diffhunk://#diff-bcef784989b8b76801975cd7d8375e5158fa072f21b6849e6ed5747f436dd294L92-R92): Added return type annotation to `__post_init__` method.
* [`src/qs_codec/models/encode_options.py`](diffhunk://#diff-5a78e1b043c4e5806aaef9634b8b64c36122dfa78163066306cd39d6f9e472daL84-R84): Added return type annotation to `__post_init__` method and removed unnecessary type ignore comment. [[1]](diffhunk://#diff-5a78e1b043c4e5806aaef9634b8b64c36122dfa78163066306cd39d6f9e472daL84-R84) [[2]](diffhunk://#diff-5a78e1b043c4e5806aaef9634b8b64c36122dfa78163066306cd39d6f9e472daL97-R97)

### Other Changes:

* [`src/qs_codec/models/undefined.py`](diffhunk://#diff-f49d80aef1ac19a71c9939dc6dd035404156b7663623db9a3162d95907177b6cR3-R14): Added type annotations to the `__new__` method of the `Undefined` class.
* [`src/qs_codec/models/weak_wrapper.py`](diffhunk://#diff-41a76e6326b30e5c4dfabd13ea65286bf048806b68d1c42fcb20b6c42efcf2c7L18-R23): Added type annotations to `_hash_recursive` method parameters.
* [`src/qs_codec/utils/decode_utils.py`](diffhunk://#diff-6f95dad5884561a3ded87aa04decf5d4d2f772152f4f712f485955abafee492aL36-R36): Removed an unnecessary type cast in the `replacer` function.
* [`src/qs_codec/utils/utils.py`](diffhunk://#diff-729a1db638a9f7b0b75f520286320950f9c1d9596ac653e86381e99c41152a9cL18-R21): Updated type annotations for multiple methods to specify element types in lists, tuples, and mappings. [[1]](diffhunk://#diff-729a1db638a9f7b0b75f520286320950f9c1d9596ac653e86381e99c41152a9cL18-R21) [[2]](diffhunk://#diff-729a1db638a9f7b0b75f520286320950f9c1d9596ac653e86381e99c41152a9cL110-R116) [[3]](diffhunk://#diff-729a1db638a9f7b0b75f520286320950f9c1d9596ac653e86381e99c41152a9cL134-R134) [[4]](diffhunk://#diff-729a1db638a9f7b0b75f520286320950f9c1d9596ac653e86381e99c41152a9cL150-R151) [[5]](diffhunk://#diff-729a1db638a9f7b0b75f520286320950f9c1d9596ac653e86381e99c41152a9cL165-R169) [[6]](diffhunk://#diff-729a1db638a9f7b0b75f520286320950f9c1d9596ac653e86381e99c41152a9cL188-R203)