### PR TITLE
:bug: fix list parsing behavior and improve test cases for DecodeOptions

### DIFF
--- a/src/qs_codec/decode.py
+++ b/src/qs_codec/decode.py
@@ -35,7 +35,7 @@ def decode(
         _parse_query_string_values(value, options) if isinstance(value, str) else value
     )
 
-    if options.parse_lists and 0 < options.list_limit < len(temp_obj):
+    if temp_obj is not None and options.parse_lists and 0 < options.list_limit < len(temp_obj):
         options.parse_lists = False
 
     # Iterate over the keys and setup the new object

--- a/src/qs_codec/decode.py
+++ b/src/qs_codec/decode.py
@@ -35,6 +35,9 @@ def decode(
         _parse_query_string_values(value, options) if isinstance(value, str) else value
     )
 
+    if options.parse_lists and 0 < options.list_limit < len(temp_obj):
+        options.parse_lists = False
+
     # Iterate over the keys and setup the new object
     if temp_obj:
         for key, val in temp_obj.items():

--- a/src/qs_codec/utils/utils.py
+++ b/src/qs_codec/utils/utils.py
@@ -38,7 +38,7 @@ class Utils:
                     else:
                         target_[len(target_)] = source
 
-                    if any(isinstance(value, Undefined) for value in target_.values()):
+                    if not options.parse_lists and any(isinstance(value, Undefined) for value in target_.values()):
                         target = {str(i): target_[i] for i in target_ if not isinstance(target_[i], Undefined)}
                     else:
                         target = list(filter(lambda el: not isinstance(el, Undefined), target_.values()))

--- a/tests/unit/example_test.py
+++ b/tests/unit/example_test.py
@@ -120,7 +120,7 @@ class TestDecoding:
         # Note that the only difference between an index in a `list` and a key in a `dict` is that the value between the
         # brackets must be a number to create a `list`. When creating `list`s with specific indices, **qs_codec** will compact
         # a sparse `list` to only the existing values preserving their order:
-        assert qs_codec.decode("a[1]=b&a[15]=c") == {"a": {"1": "b", "15": "c"}}
+        assert qs_codec.decode("a[1]=b&a[15]=c") == {"a": ["b", "c"]}
 
         # Note that an empty string is also a value, and will be preserved:
         assert qs_codec.decode("a[]=&a[]=b") == {"a": ["", "b"]}


### PR DESCRIPTION
This pull request introduces changes to the query string decoding logic in `qs_codec` to improve handling of lists, particularly sparse and nested lists, and updates the corresponding unit tests to reflect the new behavior. The most significant changes include adding a safeguard for list limits, modifying the merging behavior for undefined values, and enhancing test cases for better coverage of edge cases.

### Changes to decoding logic:

* **Safeguard for list limits**: Added a condition in `decode` to disable list parsing when the number of elements exceeds the `list_limit` specified in `DecodeOptions` (`src/qs_codec/decode.py`).
* **Merging behavior update**: Updated the `merge` function to consider the `parse_lists` option when handling undefined values, ensuring consistent behavior based on configuration (`src/qs_codec/utils/utils.py`).

### Updates to test cases:

* **Revised test expectations**: Adjusted test cases to reflect the new behavior of compacting sparse lists and handling list limits, including changes to `test_parses_an_explicit_list`, `test_parses_a_nested_list`, and `test_compacts_sparse_lists` (`tests/unit/decode_test.py`). [[1]](diffhunk://#diff-849ca855cc7b629089e14da750ce965730c302c4a369a32077a17f5622797100L255-R255) [[2]](diffhunk://#diff-849ca855cc7b629089e14da750ce965730c302c4a369a32077a17f5622797100R293-R316) [[3]](diffhunk://#diff-849ca855cc7b629089e14da750ce965730c302c4a369a32077a17f5622797100L516-L531)
* **Example test update**: Updated the example test to reflect the new behavior of compacting sparse lists (`tests/unit/example_test.py`).

---

Fixes #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved decoding of query strings to handle list parsing more consistently, especially for sparse or indexed lists.
  - Adjusted behavior so that lists with missing or non-sequential indices are now compacted into standard lists rather than dictionaries with string keys, depending on decoding options.

- **Tests**
  - Updated and added test cases to reflect the new list compaction behavior and ensure reliable decoding results for various query string formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->