### PR TITLE
:bug: preserve percent-encoded dots in keys during decoding; add DecodeKind for key/value context

### DIFF
--- a/src/qs_codec/decode.py
+++ b/src/qs_codec/decode.py
@@ -14,9 +14,12 @@ so that behavior across ports stays predictable and easy to verify with shared t
 
 import re
 import typing as t
+from collections.abc import Mapping
+from dataclasses import replace
 from math import isinf
 
 from .enums.charset import Charset
+from .enums.decode_kind import DecodeKind
 from .enums.duplicates import Duplicates
 from .enums.sentinel import Sentinel
 from .models.decode_options import DecodeOptions
@@ -26,8 +29,8 @@ from .utils.utils import Utils
 
 
 def decode(
-    value: t.Optional[t.Union[str, t.Mapping[str, t.Any]]],
-    options: DecodeOptions = DecodeOptions(),
+    value: t.Optional[t.Union[str, Mapping[str, t.Any]]],
+    options: t.Optional[DecodeOptions] = None,
 ) -> t.Dict[str, t.Any]:
     """
     Decode a query string (or a pre-tokenized mapping) into a nested ``Dict[str, Any]``.
@@ -60,30 +63,34 @@ def decode(
     if not value:
         return obj
 
-    if not isinstance(value, (str, dict)):
-        raise ValueError("The input must be a String or a Dict")
+    if not isinstance(value, (str, Mapping)):
+        raise ValueError("The input must be a String or a Mapping")
+
+    # Work on a local copy so any internal toggles don't leak to caller
+    opts = replace(options) if options is not None else DecodeOptions()
 
     temp_obj: t.Optional[t.Dict[str, t.Any]] = (
-        _parse_query_string_values(value, options) if isinstance(value, str) else value
+        _parse_query_string_values(value, opts) if isinstance(value, str) else dict(value)
     )
 
-    # If a raw query string produced *more parts than list_limit*, turn list parsing off.
-    # This prevents O(n^2) behavior when the input is a very large flat list of tokens.
-    # We only toggle for this call (mutating the local `options` instance by design,
-    # consistent with the other ports).
-    if temp_obj is not None and options.parse_lists and 0 < options.list_limit < len(temp_obj):
-        options.parse_lists = False
+    # Temporarily toggle parse_lists for THIS call only, and only for raw strings
+    orig_parse_lists = opts.parse_lists
+    try:
+        if isinstance(value, str) and temp_obj is not None and orig_parse_lists and 0 < opts.list_limit < len(temp_obj):
+            opts.parse_lists = False
 
-    # Iterate over the keys and setup the new object
-    if temp_obj:
-        for key, val in temp_obj.items():
-            new_obj: t.Any = _parse_keys(key, val, options, isinstance(value, str))
+        # Iterate over the keys and setup the new object
+        if temp_obj:
+            for key, val in temp_obj.items():
+                new_obj: t.Any = _parse_keys(key, val, opts, isinstance(value, str))
 
-            if not obj and isinstance(new_obj, dict):
-                obj = new_obj
-                continue
+                if not obj and isinstance(new_obj, dict):
+                    obj = new_obj
+                    continue
 
-            obj = Utils.merge(obj, new_obj, options)  # type: ignore [assignment]
+                obj = Utils.merge(obj, new_obj, opts)  # type: ignore [assignment]
+    finally:
+        opts.parse_lists = orig_parse_lists
 
     return Utils.compact(obj)
 
@@ -92,7 +99,7 @@ def decode(
 load = decode
 
 
-def loads(value: t.Optional[str], options: DecodeOptions = DecodeOptions()) -> t.Dict[str, t.Any]:
+def loads(value: t.Optional[str], options: t.Optional[DecodeOptions] = None) -> t.Dict[str, t.Any]:
     """
     Alias for ``decode``. Decodes a query string into a ``Dict[str, Any]``.
 
@@ -168,21 +175,30 @@ def _parse_query_string_values(value: str, options: DecodeOptions) -> t.Dict[str
         raise ValueError("Parameter limit must be a positive integer.")
 
     parts: t.List[str]
-    # Split using either a compiled regex or a literal string delimiter (do it once, then slice if needed).
-    if isinstance(options.delimiter, re.Pattern):
-        _all_parts = re.split(options.delimiter, clean_str)
+    if limit is None:
+        # Unlimited parameters: split fully
+        if isinstance(options.delimiter, re.Pattern):
+            parts = re.split(options.delimiter, clean_str)
+        else:
+            parts = clean_str.split(options.delimiter)
     else:
-        _all_parts = clean_str.split(options.delimiter)
-
-    if (limit is not None) and limit:
-        _take = limit + 1 if options.raise_on_limit_exceeded else limit
-        parts = _all_parts[:_take]
-    else:
-        parts = _all_parts
-
-    # Enforce parameter count when strict mode is enabled.
-    if options.raise_on_limit_exceeded and (limit is not None) and len(parts) > limit:
-        raise ValueError(f"Parameter limit exceeded: Only {limit} parameter{'' if limit == 1 else 's'} allowed.")
+        if options.raise_on_limit_exceeded:
+            # Split to at most limit+1 parts so we can detect overflow
+            if isinstance(options.delimiter, re.Pattern):
+                parts = re.split(options.delimiter, clean_str, maxsplit=limit)
+            else:
+                parts = clean_str.split(options.delimiter, limit)
+            if len(parts) > limit:
+                raise ValueError(
+                    f"Parameter limit exceeded: Only {limit} parameter{'s' if limit != 1 else ''} allowed."
+                )
+        else:
+            # Silent degrade: split fully, then take the first `limit` parts
+            if isinstance(options.delimiter, re.Pattern):
+                parts = re.split(options.delimiter, clean_str)
+            else:
+                parts = clean_str.split(options.delimiter)
+            parts = parts[:limit]
 
     skip_index: int = -1  # Keep track of where the utf8 sentinel was found
     i: int
@@ -200,6 +216,9 @@ def _parse_query_string_values(value: str, options: DecodeOptions) -> t.Dict[str
                 skip_index = i
                 break
 
+    # Local, non-optional decoder reference for type-checkers
+    decoder_fn: t.Callable[..., t.Optional[str]] = options.decoder or DecodeUtils.decode
+
     # Iterate over parts and decode each key/value pair.
     for i, _ in enumerate(parts):
         if i == skip_index:
@@ -209,20 +228,25 @@ def _parse_query_string_values(value: str, options: DecodeOptions) -> t.Dict[str
         bracket_equals_pos: int = part.find("]=")
         pos: int = part.find("=") if bracket_equals_pos == -1 else (bracket_equals_pos + 1)
 
-        key: str
-        val: t.Union[t.List[t.Any], t.Tuple[t.Any], str, t.Any]
+        # Decode key and value with a key-aware decoder; skip pairs whose key decodes to None
         if pos == -1:
-            key = options.decoder(part, charset)
-            val = None if options.strict_null_handling else ""
+            key_decoded = decoder_fn(part, charset, kind=DecodeKind.KEY)
+            if key_decoded is None:
+                continue
+            key: str = key_decoded
+            val: t.Any = None if options.strict_null_handling else ""
         else:
-            key = options.decoder(part[:pos], charset)
+            key_decoded = decoder_fn(part[:pos], charset, kind=DecodeKind.KEY)
+            if key_decoded is None:
+                continue
+            key = key_decoded
             val = Utils.apply(
                 _parse_array_value(
                     part[pos + 1 :],
                     options,
                     len(obj[key]) if key in obj and isinstance(obj[key], (list, tuple)) else 0,
                 ),
-                lambda v: options.decoder(v, charset),
+                lambda v: decoder_fn(v, charset, kind=DecodeKind.VALUE),
             )
 
         if val and options.interpret_numeric_entities and charset == Charset.LATIN1:
@@ -344,7 +368,7 @@ def _parse_keys(given_key: t.Optional[str], val: t.Any, options: DecodeOptions, 
 
     keys: t.List[str] = DecodeUtils.split_key_into_segments(
         original_key=given_key,
-        allow_dots=options.allow_dots,
+        allow_dots=t.cast(bool, options.allow_dots),
         max_depth=options.depth,
         strict_depth=options.strict_depth,
     )

--- a/src/qs_codec/enums/decode_kind.py
+++ b/src/qs_codec/enums/decode_kind.py
@@ -1,0 +1,30 @@
+"""Decoding context used by the query string parser and utilities.
+
+This enum indicates whether a given piece of text is being decoded as a *key*
+(or key segment) or as a *value*. The distinction matters for encoded dots
+(``%2E``/``%2e``) in keys: when decoding keys, the default behavior is to
+*preserve* these so that higher‑level options like ``allow_dots`` and
+``decode_dot_in_keys`` can be applied consistently later in the parse.
+"""
+
+from enum import Enum
+
+
+class DecodeKind(Enum):
+    """Decoding context for querystring tokens.
+
+    Attributes
+    ----------
+    KEY
+        Decode a *key* (or key segment). Implementations typically preserve
+        percent‑encoded dots (``%2E``/``%2e``) so that dot‑splitting semantics can
+        be applied later according to parser options.
+    VALUE
+        Decode a *value*. Implementations typically perform full percent decoding.
+    """
+
+    KEY = 1  # Key/segment decode; preserve encoded dots for later splitting logic
+    VALUE = 2  # Value decode; fully percent-decode
+
+
+__all__ = ["DecodeKind"]

--- a/src/qs_codec/utils/decode_utils.py
+++ b/src/qs_codec/utils/decode_utils.py
@@ -11,6 +11,7 @@ import typing as t
 from urllib.parse import unquote
 
 from ..enums.charset import Charset
+from ..enums.decode_kind import DecodeKind
 
 
 class DecodeUtils:
@@ -68,15 +69,18 @@ class DecodeUtils:
         cls,
         string: t.Optional[str],
         charset: t.Optional[Charset] = Charset.UTF8,
+        kind: DecodeKind = DecodeKind.VALUE,
     ) -> t.Optional[str]:
         """Decode a URL‑encoded scalar.
 
         Behavior:
         - Replace ``+`` with a literal space *before* decoding.
         - If ``charset`` is :data:`~qs_codec.enums.charset.Charset.LATIN1`,
-        replace only ``%XX`` byte sequences using :meth:`DecodeUtils.unescape`.
-        ``%uXXXX`` sequences are left as‑is here to mimic older browser/JS behavior.
+          decode only ``%XX`` byte sequences (no ``%uXXXX``). ``%uXXXX`` sequences are left as‑is
+          to mimic older browser/JS behavior.
         - Otherwise (UTF‑8), defer to :func:`urllib.parse.unquote`.
+        - When ``kind=DecodeKind.KEY``, preserve percent-encoded dots (``%2E``/``%2e``) so key splitting honors
+          ``allow_dots``/``decode_dot_in_keys``. Values always decode fully.
 
         Returns
         -------
@@ -94,9 +98,22 @@ class DecodeUtils:
             s = string_without_plus
             if "%" not in s:
                 return s
-            return cls.HEX2_PATTERN.sub(lambda m: chr(int(m.group(1), 16)), s)
+            if kind is DecodeKind.KEY:
+
+                def _latin1_key_replacer(m: t.Match[str]) -> str:
+                    hx = m.group(1)
+                    if hx.lower() == "2e":  # keep %2E/%2e literal in keys
+                        return "%" + hx
+                    return chr(int(hx, 16))
+
+                return cls.HEX2_PATTERN.sub(_latin1_key_replacer, s)
+            else:
+                return cls.HEX2_PATTERN.sub(lambda m: chr(int(m.group(1), 16)), s)
 
         s = string_without_plus
+        if kind is DecodeKind.KEY and "%2" in s:
+            # Protect encoded dots so unquote does not turn them into literal '.' for keys
+            s = s.replace("%2E", "%252E").replace("%2e", "%252e")
         return s if "%" not in s else unquote(s)
 
     @classmethod
@@ -118,7 +135,7 @@ class DecodeUtils:
         This runs in O(n) time over the key string.
         """
         if allow_dots and "." in original_key:
-            key: str = cls.DOT_TO_BRACKET.sub(r"[\1]", original_key)
+            key: str = cls.DOT_TO_BRACKET.sub(r"[\g<1>]", original_key)
         else:
             key = original_key
 


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the query string decoding logic. The main focus is on enhancing key/value decoding flexibility by introducing a `DecodeKind` enum, improving compatibility with custom decoders, and refining parameter splitting and type handling. These changes make the decoding process more robust, customizable, and maintainable.

### Decoding logic and flexibility

* Added the `DecodeKind` enum to distinguish between decoding keys and values, enabling context-aware decoding and better handling of percent-encoded dots in keys. (`src/qs_codec/enums/decode_kind.py`)
* Updated the main `decode` function and its helpers to use `DecodeKind`, passing the decoding context to decoders and allowing custom decoders to adapt based on whether a token is a key or value. (`src/qs_codec/decode.py`, `src/qs_codec/models/decode_options.py`, `src/qs_codec/utils/decode_utils.py`) [[1]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3R17-R22) [[2]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L29-R33) [[3]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L63-R93) [[4]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3R219-R221) [[5]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L212-R249) [[6]](diffhunk://#diff-bcef784989b8b76801975cd7d8375e5158fa072f21b6849e6ed5747f436dd294L119-R126) [[7]](diffhunk://#diff-bcef784989b8b76801975cd7d8375e5158fa072f21b6849e6ed5747f436dd294R140-R165) [[8]](diffhunk://#diff-6f95dad5884561a3ded87aa04decf5d4d2f772152f4f712f485955abafee492aR14) [[9]](diffhunk://#diff-6f95dad5884561a3ded87aa04decf5d4d2f772152f4f712f485955abafee492aR72-R83) [[10]](diffhunk://#diff-6f95dad5884561a3ded87aa04decf5d4d2f772152f4f712f485955abafee492aR101-R116)
* Enhanced the default decoder to preserve percent-encoded dots in keys and fully decode values, ensuring dot notation is handled consistently according to parser options. (`src/qs_codec/utils/decode_utils.py`)

### API and type improvements

* Changed `decode` and `loads` to accept `options: Optional[DecodeOptions]`, and improved type hints for better flexibility and clarity. (`src/qs_codec/decode.py`) [[1]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L29-R33) [[2]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L95-R102)
* Updated internal usage to prefer `Mapping` over `dict` for input types, improving compatibility with various mapping types. (`src/qs_codec/decode.py`) [[1]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3R17-R22) [[2]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L29-R33) [[3]](diffhunk://#diff-799c474eada8f1209c56fda969560ff6762067fbccf00a6f4cd500cf90a621e3L63-R93)

### Parameter splitting and key parsing

* Refactored query string splitting logic to more accurately enforce parameter limits, using `maxsplit` and improved error handling for strict mode. (`src/qs_codec/decode.py`)
* Fixed key segment splitting to use a more robust regex substitution, ensuring correct bracket notation when converting dot notation. (`src/qs_codec/utils/decode_utils.py`)

### Option handling and compatibility

* Improved `DecodeOptions` to support optional `allow_dots` and `decode_dot_in_keys`, and added a compatibility wrapper for custom decoders to support the new `kind` argument. (`src/qs_codec/models/decode_options.py`) [[1]](diffhunk://#diff-bcef784989b8b76801975cd7d8375e5158fa072f21b6849e6ed5747f436dd294L4-R7) [[2]](diffhunk://#diff-bcef784989b8b76801975cd7d8375e5158fa072f21b6849e6ed5747f436dd294L15-R19) [[3]](diffhunk://#diff-bcef784989b8b76801975cd7d8375e5158fa072f21b6849e6ed5747f436dd294L119-R126) [[4]](diffhunk://#diff-bcef784989b8b76801975cd7d8375e5158fa072f21b6849e6ed5747f436dd294R140-R165)

These changes collectively make the query string decoding process more robust, customizable, and easier to extend for future use cases.