### PR TITLE
chore: align with upstream changes from Node qs v6.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.1-dev
+
+* [FIX] align `decode` with Node `qs` 6.15.2 by normalizing dotted keys before preserving `depth=0` input
+* [FIX] align `encode` with Node `qs` 6.15.2 by using the configured delimiter after `charset_sentinel`
+
 ## 1.5.0
 
 * [FEAT] add the `Programming Language :: Python :: Free Threading :: 3 - Stable` classifier

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ To ensure compatibility with the Node.js package, please run the following comma
 pushd test/comparison || exit 1
 
 # Install the Node.js dependencies
-npm install
+pnpm install --frozen-lockfile
 
 # Run the JavaScript and Python scripts and save their outputs
 node_output=$(node qs.js)

--- a/src/qs_codec/encode.py
+++ b/src/qs_codec/encode.py
@@ -179,9 +179,9 @@ def encode(value: t.Any, options: t.Optional[EncodeOptions] = None) -> str:
     # Optional charset sentinel token for downstream parsers (e.g., "utf-8" or "iso-8859-1").
     if opts.charset_sentinel:
         if opts.charset == Charset.LATIN1:
-            prefix += f"{Sentinel.ISO.encoded}&"
+            prefix += f"{Sentinel.ISO.encoded}{opts.delimiter}"
         elif opts.charset == Charset.UTF8:
-            prefix += f"{Sentinel.CHARSET.encoded}&"
+            prefix += f"{Sentinel.CHARSET.encoded}{opts.delimiter}"
         else:
             raise ValueError("Invalid charset")
 

--- a/src/qs_codec/utils/decode_utils.py
+++ b/src/qs_codec/utils/decode_utils.py
@@ -226,10 +226,10 @@ class DecodeUtils:
 
         This runs in O(n) time over the key string.
         """
-        if max_depth <= 0:
-            return [original_key]
-
         key: str = cls.dot_to_bracket_top_level(original_key) if allow_dots else original_key
+
+        if max_depth <= 0:
+            return [key]
 
         segments: t.List[str] = []
 

--- a/tests/comparison/package.json
+++ b/tests/comparison/package.json
@@ -6,6 +6,6 @@
   "license": "BSD-3-Clause",
   "packageManager": "pnpm@11.1.3",
   "dependencies": {
-    "qs": "^6.15.1"
+    "qs": "^6.15.2"
   }
 }

--- a/tests/comparison/pnpm-lock.yaml
+++ b/tests/comparison/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       qs:
-        specifier: ^6.15.1
-        version: 6.15.1
+        specifier: ^6.15.2
+        version: 6.15.2
 
 packages:
 
@@ -69,8 +69,8 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==, tarball: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz}
     engines: {node: '>= 0.4'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.1.tgz}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.2.tgz}
     engines: {node: '>=0.6'}
 
   side-channel-list@1.0.1:
@@ -147,7 +147,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/tests/unit/decode_test.py
+++ b/tests/unit/decode_test.py
@@ -303,6 +303,9 @@ class TestDecode:
     def test_uses_original_key_when_depth_is_0(self, query: str, expected: t.Dict) -> None:
         assert decode(query, DecodeOptions(depth=0)) == expected
 
+    def test_depth_0_normalizes_dots_before_preserving_original_key(self) -> None:
+        assert decode("a.b=c", DecodeOptions(depth=0, allow_dots=True)) == {"a[b]": "c"}
+
     def test_parses_a_simple_list(self) -> None:
         assert decode("a=b&a=c") == {"a": ["b", "c"]}
 
@@ -1859,9 +1862,9 @@ class TestAdditionalDotEncodingParity:
         assert decode("a%2Eb", opt2) == {"a": {"b": ""}}
 
     def test_depth_zero_with_allowdots_true_does_not_split_key(self) -> None:
-        # depth=0 with allowDots=true: do not split key
+        # qs normalizes allowDots notation before preserving the full depth=0 key.
         opt = DecodeOptions(allow_dots=True, depth=0)
-        assert decode("a.b=c", opt) == {"a.b": "c"}
+        assert decode("a.b=c", opt) == {"a[b]": "c"}
 
     def test_top_level_dot_to_bracket_guardrails_leading_trailing_double(self) -> None:
         # Leading dot: ".a" should yield {"a": ...} when allowDots=true
@@ -1925,6 +1928,10 @@ class TestSplitKeySegmentationRemainder:
     def test_unterminated_group_does_not_raise_under_strict_depth(self) -> None:
         segs = DecodeUtils.split_key_into_segments("a[b[c", allow_dots=False, max_depth=5, strict_depth=True)
         assert segs == ["a", "[[b[c]"]
+
+    def test_depth_zero_normalizes_dots_before_preserving_segment(self) -> None:
+        segs = DecodeUtils.split_key_into_segments("a.b", allow_dots=True, max_depth=0, strict_depth=False)
+        assert segs == ["a[b]"]
 
 
 class TestCVE2024:

--- a/tests/unit/encode_test.py
+++ b/tests/unit/encode_test.py
@@ -959,6 +959,29 @@ class TestEncode:
         assert encode(data, options) == expected
 
     @pytest.mark.parametrize(
+        "data, options, expected",
+        [
+            pytest.param(
+                {"a": "b", "undefined": "x", "c": "d"},
+                EncodeOptions(filter=["a", Undefined(), "c"]),
+                "a=b&c=d",
+                id="undefined-filter-entry",
+            ),
+            pytest.param(
+                {"a": "b", "null": "x", "c": "d"},
+                EncodeOptions(filter=["a", None, "c"]),
+                "a=b&c=d",
+                id="none-filter-entry",
+            ),
+            pytest.param({"null": "x"}, EncodeOptions(filter=[None]), "", id="only-none-filter-entry"),
+        ],
+    )
+    def test_filter_list_skips_none_and_undefined_entries(
+        self, data: t.Mapping[str, t.Any], options: EncodeOptions, expected: str
+    ) -> None:
+        assert encode(data, options) == expected
+
+    @pytest.mark.parametrize(
         "sequence, expected",
         [
             pytest.param([1, 2], "a%5B0%5D=1", id="list"),
@@ -1293,6 +1316,9 @@ class TestEncode:
     def test_charset_sentinel_option(self, data: t.Mapping[str, t.Any], options: EncodeOptions, expected: str) -> None:
         assert encode(data, options) == expected
 
+    def test_charset_sentinel_uses_configured_delimiter(self) -> None:
+        assert encode({"a": 1, "b": 2}, EncodeOptions(charset_sentinel=True, delimiter=";")) == "utf8=%E2%9C%93;a=1;b=2"
+
     def test_charset_sentinel_with_invalid_charset(self) -> None:
         # Create a custom EncodeOptions with an invalid charset
         options = EncodeOptions(charset_sentinel=True)
@@ -1620,6 +1646,46 @@ class TestEncodesAListValueWithOneItemVsMultipleItems:
         ],
     )
     def test_list_with_multiple_items_with_a_comma_inside(
+        self, data: t.Mapping[str, t.Any], options: EncodeOptions, expected: str
+    ) -> None:
+        assert encode(data, options) == expected
+
+    @pytest.mark.parametrize(
+        "data, options, expected",
+        [
+            pytest.param(
+                {"a": [None, "b"]},
+                EncodeOptions(list_format=ListFormat.COMMA, encode_values_only=True),
+                "a=,b",
+                id="none-slot",
+            ),
+            pytest.param(
+                {"a": [Undefined(), "b"]},
+                EncodeOptions(list_format=ListFormat.COMMA, encode_values_only=True),
+                "a=,b",
+                id="undefined-slot",
+            ),
+            pytest.param(
+                {"a": [None]},
+                EncodeOptions(list_format=ListFormat.COMMA, encode_values_only=True),
+                "a=",
+                id="single-none",
+            ),
+            pytest.param(
+                {"a": [None]},
+                EncodeOptions(list_format=ListFormat.COMMA, encode_values_only=True, strict_null_handling=True),
+                "a",
+                id="single-none-strict-null",
+            ),
+            pytest.param(
+                {"a": [None]},
+                EncodeOptions(list_format=ListFormat.COMMA, encode_values_only=True, skip_nulls=True),
+                "",
+                id="single-none-skip-nulls",
+            ),
+        ],
+    )
+    def test_comma_values_only_nullish_entries_are_empty_slots(
         self, data: t.Mapping[str, t.Any], options: EncodeOptions, expected: str
     ) -> None:
         assert encode(data, options) == expected


### PR DESCRIPTION
This pull request updates the Python `qs_codec` package to align its `encode` and `decode` behavior with Node `qs` version 6.15.2, ensuring improved compatibility and correctness. The changes include bug fixes to key normalization and delimiter handling, dependency updates for comparison tests, and new or updated tests to verify the new behavior.

**Compatibility and Bug Fixes:**

* The `decode` function now normalizes dotted keys before preserving them when `depth=0` and `allow_dots=True`, matching Node `qs` 6.15.2 behavior. [[1]](diffhunk://#diff-6f95dad5884561a3ded87aa04decf5d4d2f772152f4f712f485955abafee492aL229-R233) [[2]](diffhunk://#diff-849ca855cc7b629089e14da750ce965730c302c4a369a32077a17f5622797100L1862-R1867) [[3]](diffhunk://#diff-849ca855cc7b629089e14da750ce965730c302c4a369a32077a17f5622797100R1932-R1935) [[4]](diffhunk://#diff-849ca855cc7b629089e14da750ce965730c302c4a369a32077a17f5622797100R306-R308)
* The `encode` function now uses the configured delimiter after the `charset_sentinel` token, aligning with the latest Node `qs` behavior. [[1]](diffhunk://#diff-a1d443c188edfa1734eca359a4ebca123ce86b539c9084a9f6eee19195e435a3L182-R184) [[2]](diffhunk://#diff-bb9e56847b67a00421343025e6c7fa178d4bea774ddc877c0ab5ccf030c75254R1319-R1321)

**Dependency and Test Infrastructure Updates:**

* Updated the comparison test suite to use `qs@6.15.2` and switched from `npm` to `pnpm` for dependency installation, ensuring tests run against the correct Node.js version. [[1]](diffhunk://#diff-0beea0c3ab717b7dad686ab06f8850dead4e91c69e9f5d132d79d5da6ce5d7a6L9-R9) [[2]](diffhunk://#diff-e0d99eb90c1c0e54d8c5aaaac74f5de78128c5fbe680bc4fcc2b2d4056a0cad7L12-R13) [[3]](diffhunk://#diff-e0d99eb90c1c0e54d8c5aaaac74f5de78128c5fbe680bc4fcc2b2d4056a0cad7L72-R73) [[4]](diffhunk://#diff-e0d99eb90c1c0e54d8c5aaaac74f5de78128c5fbe680bc4fcc2b2d4056a0cad7L150-R150) [[5]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L54-R54)

**Testing Improvements:**

* Added and updated tests to verify correct handling of dotted keys with `depth=0`, delimiter configuration with `charset_sentinel`, and filtering/encoding of `None` and `Undefined` values in both top-level and list contexts. [[1]](diffhunk://#diff-849ca855cc7b629089e14da750ce965730c302c4a369a32077a17f5622797100R306-R308) [[2]](diffhunk://#diff-bb9e56847b67a00421343025e6c7fa178d4bea774ddc877c0ab5ccf030c75254R961-R983) [[3]](diffhunk://#diff-bb9e56847b67a00421343025e6c7fa178d4bea774ddc877c0ab5ccf030c75254R1653-R1692) [[4]](diffhunk://#diff-bb9e56847b67a00421343025e6c7fa178d4bea774ddc877c0ab5ccf030c75254R1319-R1321)

**Documentation:**

* Updated `CHANGELOG.md` to document the bug fixes and compatibility improvements in version 1.5.1-dev.